### PR TITLE
Remove emojis for cleaner business UI

### DIFF
--- a/Schreibtisch/vertriebsberichte-app/frontend/src/components/LanguageSwitcher.tsx
+++ b/Schreibtisch/vertriebsberichte-app/frontend/src/components/LanguageSwitcher.tsx
@@ -15,8 +15,8 @@ const LanguageSwitcher = () => {
         className="px-3 py-1 text-sm bg-gray-700 text-white border border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 hover:bg-gray-600"
         title={t('common:language.selectLanguage')}
       >
-        <option value="de">🇩🇪 DE</option>
-        <option value="en">🇬🇧 EN</option>
+        <option value="de">DE</option>
+        <option value="en">EN</option>
       </select>
     </div>
   );

--- a/Schreibtisch/vertriebsberichte-app/frontend/src/components/Layout.tsx
+++ b/Schreibtisch/vertriebsberichte-app/frontend/src/components/Layout.tsx
@@ -86,7 +86,7 @@ const Layout = () => {
                   {/* Dashboard */}
                   <NavLink to="/dashboard" className={navLinkClass}>
                     <span className="flex items-center">
-                      📊 {t('common:navigation.dashboard')}
+                       {t('common:navigation.dashboard')}
                     </span>
                   </NavLink>
 
@@ -96,7 +96,7 @@ const Layout = () => {
                       onClick={() => setIsReportsDropdownOpen(!isReportsDropdownOpen)}
                       className="px-3 py-2 rounded-md text-sm font-medium text-gray-300 hover:bg-gray-700 hover:text-white transition-colors duration-200 flex items-center"
                     >
-                      📋 {t('common:navigation.reports')}
+                       {t('common:navigation.reports')}
                       <svg className="ml-1 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
                       </svg>
@@ -105,10 +105,10 @@ const Layout = () => {
                       <div className="absolute left-0 mt-2 w-48 rounded-md shadow-lg bg-gray-800 ring-1 ring-black ring-opacity-5 z-50">
                         <div className="py-1">
                           <NavLink to="/reports" className={dropdownLinkClass} onClick={() => setIsReportsDropdownOpen(false)}>
-                            📄 {t('common:navigation.reports')}
+                             {t('common:navigation.reports')}
                           </NavLink>
                           <NavLink to="/reports/new" className={dropdownLinkClass} onClick={() => setIsReportsDropdownOpen(false)}>
-                            ➕ {t('common:buttons.new')}
+                             {t('common:buttons.new')}
                           </NavLink>
                         </div>
                       </div>
@@ -121,7 +121,7 @@ const Layout = () => {
                       onClick={() => setIsAnalyticsDropdownOpen(!isAnalyticsDropdownOpen)}
                       className="px-3 py-2 rounded-md text-sm font-medium text-gray-300 hover:bg-gray-700 hover:text-white transition-colors duration-200 flex items-center"
                     >
-                      📈 {t('common:navigation.analytics')}
+                       {t('common:navigation.analytics')}
                       <svg className="ml-1 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
                       </svg>
@@ -130,7 +130,7 @@ const Layout = () => {
                       <div className="absolute left-0 mt-2 w-48 rounded-md shadow-lg bg-gray-800 ring-1 ring-black ring-opacity-5 z-50">
                         <div className="py-1">
                           <NavLink to="/statistics" className={dropdownLinkClass} onClick={() => setIsAnalyticsDropdownOpen(false)}>
-                            📊 {t('common:navigation.analytics')}
+                             {t('common:navigation.analytics')}
                           </NavLink>
                           <WithPermission permission="view_analytics">
                             <NavLink to="/analytics" className={dropdownLinkClass} onClick={() => setIsAnalyticsDropdownOpen(false)}>
@@ -139,7 +139,7 @@ const Layout = () => {
                           </WithPermission>
                           <ManagerOrAdmin>
                             <NavLink to="/statistics/global" className={dropdownLinkClass} onClick={() => setIsAnalyticsDropdownOpen(false)}>
-                              🌍 {t('common:navigation.globalStatistics')}
+                               {t('common:navigation.globalStatistics')}
                             </NavLink>
                           </ManagerOrAdmin>
                         </div>
@@ -154,7 +154,7 @@ const Layout = () => {
                         onClick={() => setIsAdminDropdownOpen(!isAdminDropdownOpen)}
                         className="px-3 py-2 rounded-md text-sm font-medium text-gray-300 hover:bg-gray-700 hover:text-white transition-colors duration-200 flex items-center"
                       >
-                        ⚙️ {t('common:navigation.adminDashboard')}
+                        {t('common:navigation.adminDashboard')}
                         <svg className="ml-1 h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
                         </svg>
@@ -163,7 +163,7 @@ const Layout = () => {
                         <div className="absolute left-0 mt-2 w-48 rounded-md shadow-lg bg-gray-800 ring-1 ring-black ring-opacity-5 z-50">
                           <div className="py-1">
                             <NavLink to="/admin/users" className={dropdownLinkClass} onClick={() => setIsAdminDropdownOpen(false)}>
-                              👥 {t('common:navigation.adminDashboard')}
+                               {t('common:navigation.adminDashboard')}
                             </NavLink>
                           </div>
                         </div>
@@ -187,9 +187,9 @@ const Layout = () => {
                   <div className="text-sm font-medium">{user?.name}</div>
                   {userPermissions?.roleName && (
                     <div className="text-xs text-gray-400">
-                      {userPermissions.roleName === 'admin' && `👑 ${t('auth:roles.admin')}`}
-                      {userPermissions.roleName === 'manager' && `📊 ${t('auth:roles.manager')}`}
-                      {userPermissions.roleName === 'employee' && `👤 ${t('auth:roles.employee')}`}
+                      {userPermissions.roleName === 'admin' && t('auth:roles.admin')}
+                      {userPermissions.roleName === 'manager' && t('auth:roles.manager')}
+                      {userPermissions.roleName === 'employee' && t('auth:roles.employee')}
                     </div>
                   )}
                 </div>
@@ -228,24 +228,24 @@ const Layout = () => {
                   <div className="text-sm font-medium">{user?.name}</div>
                   {userPermissions?.roleName && (
                     <div className="text-xs text-gray-400">
-                      {userPermissions.roleName === 'admin' && `👑 ${t('auth:roles.admin')}`}
-                      {userPermissions.roleName === 'manager' && `📊 ${t('auth:roles.manager')}`}
-                      {userPermissions.roleName === 'employee' && `👤 ${t('auth:roles.employee')}`}
+                      {userPermissions.roleName === 'admin' && t('auth:roles.admin')}
+                      {userPermissions.roleName === 'manager' && t('auth:roles.manager')}
+                      {userPermissions.roleName === 'employee' && t('auth:roles.employee')}
                     </div>
                   )}
                 </div>
 
                 <NavLink to="/dashboard" className={mobileNavLinkClass} onClick={() => setIsMobileMenuOpen(false)}>
-                  📊 {t('common:navigation.dashboard')}
+                   {t('common:navigation.dashboard')}
                 </NavLink>
                 <NavLink to="/reports" className={mobileNavLinkClass} onClick={() => setIsMobileMenuOpen(false)}>
-                  📄 {t('common:navigation.reports')}
+                   {t('common:navigation.reports')}
                 </NavLink>
                 <NavLink to="/reports/new" className={mobileNavLinkClass} onClick={() => setIsMobileMenuOpen(false)}>
-                  ➕ {t('common:buttons.new')}
+                   {t('common:buttons.new')}
                 </NavLink>
                 <NavLink to="/statistics" className={mobileNavLinkClass} onClick={() => setIsMobileMenuOpen(false)}>
-                  📊 {t('common:navigation.analytics')}
+                   {t('common:navigation.analytics')}
                 </NavLink>
                 <WithPermission permission="view_analytics">
                   <NavLink to="/analytics" className={mobileNavLinkClass} onClick={() => setIsMobileMenuOpen(false)}>
@@ -254,12 +254,12 @@ const Layout = () => {
                 </WithPermission>
                 <ManagerOrAdmin>
                   <NavLink to="/statistics/global" className={mobileNavLinkClass} onClick={() => setIsMobileMenuOpen(false)}>
-                    🌍 {t('common:navigation.globalStatistics')}
+                     {t('common:navigation.globalStatistics')}
                   </NavLink>
                 </ManagerOrAdmin>
                 <WithPermission permission="manage_users">
                   <NavLink to="/admin/users" className={mobileNavLinkClass} onClick={() => setIsMobileMenuOpen(false)}>
-                    👥 {t('common:navigation.adminDashboard')}
+                     {t('common:navigation.adminDashboard')}
                   </NavLink>
                 </WithPermission>
                 
@@ -274,7 +274,7 @@ const Layout = () => {
                   onClick={handleLogout}
                   className="w-full text-left px-3 py-2 rounded-md text-base font-medium text-gray-300 hover:bg-gray-700 hover:text-white transition-colors duration-200 mt-2"
                 >
-                  🚪 {t('common:navigation.logout')}
+                   {t('common:navigation.logout')}
                 </button>
               </div>
             </div>

--- a/Schreibtisch/vertriebsberichte-app/frontend/src/locales/de/admin.json
+++ b/Schreibtisch/vertriebsberichte-app/frontend/src/locales/de/admin.json
@@ -1,5 +1,5 @@
 {
-  "title": "👑 Admin Dashboard",
+  "title": "Admin Dashboard",
   "welcome": "Willkommen, {{name}}! Verwalten Sie Benutzer und Rollen.",
   "accessDenied": {
     "title": "Zugriff verweigert",
@@ -12,7 +12,7 @@
     "employees": "Mitarbeiter"
   },
   "userManagement": {
-    "title": "👥 Alle Benutzer",
+    "title": "Alle Benutzer",
     "table": {
       "user": "Benutzer",
       "role": "Rolle",
@@ -26,7 +26,7 @@
     }
   },
   "roleAssignment": {
-    "title": "🔧 Rolle zuweisen",
+    "title": "Rolle zuweisen",
     "selectUser": "Benutzer auswählen",
     "selectRole": "Neue Rolle",
     "userPlaceholder": "-- Benutzer wählen --",

--- a/Schreibtisch/vertriebsberichte-app/frontend/src/locales/de/common.json
+++ b/Schreibtisch/vertriebsberichte-app/frontend/src/locales/de/common.json
@@ -4,7 +4,7 @@
     "dashboard": "Dashboard",
     "reports": "Berichte",
     "analytics": "Statistiken",
-    "personalAnalytics": "🔍 Analytics",
+    "personalAnalytics": "Analytics",
     "globalStatistics": "Globale Auswertung",
     "adminDashboard": "Benutzerverwaltung",
     "logout": "Abmelden"
@@ -47,7 +47,7 @@
     "existing": "Nur Bestandskunden"
   },
   "analytics": {
-    "title": "🔍 Analytics Dashboard",
+    "title": "Analytics Dashboard",
     "subtitle": "Persönliche Leistungsanalyse für",
     "loading": "Lade Analytics-Daten...",
     "noData": "Keine Analytics-Daten verfügbar",
@@ -66,13 +66,13 @@
       "newCustomers": "Neukunden"
     },
     "charts": {
-      "monthlyTrends": "📈 Monatstrends",
-      "statusDistribution": "📋 Status-Verteilung",
-      "recentActivity": "⚡ Neueste Aktivitäten",
+      "monthlyTrends": "Monatstrends",
+      "statusDistribution": "Status-Verteilung",
+      "recentActivity": "Neueste Aktivitäten",
       "reports": "Berichte"
     },
     "insights": {
-      "title": "💡 Performance-Insights",
+      "title": "Performance-Insights",
       "avgPerReport": "Durchschnitt pro Bericht",
       "completionRate": "Abschlussquote",
       "newCustomerRate": "Neukunden-Rate"

--- a/Schreibtisch/vertriebsberichte-app/frontend/src/locales/de/globalStats.json
+++ b/Schreibtisch/vertriebsberichte-app/frontend/src/locales/de/globalStats.json
@@ -1,12 +1,12 @@
 {
-  "title": "🌍 Globale Auswertungen",
+  "title": "Globale Auswertungen",
   "subtitle": "Übersicht aller Berichte, Mitarbeiter und Kunden",
   "accessDenied": {
     "title": "Zugriff verweigert",
     "message": "Sie haben keine Berechtigung für diese globalen Auswertungen."
   },
   "dateFilter": {
-    "title": "📅 Zeitraum filtern",
+    "title": "Zeitraum filtern",
     "fromDate": "Von Datum",
     "toDate": "Bis Datum",
     "resetFilters": "Filter zurücksetzen",
@@ -24,7 +24,7 @@
     "cCustomers": "C-Kunden"
   },
   "employeePerformance": {
-    "title": "🏆 Mitarbeiter-Performance",
+    "title": "Mitarbeiter-Performance",
     "headers": {
       "employee": "Mitarbeiter",
       "region": "Region",
@@ -35,7 +35,7 @@
     }
   },
   "topCustomers": {
-    "title": "⭐ Top 20 Kunden",
+    "title": "Top 20 Kunden",
     "headers": {
       "customer": "Kunde",
       "class": "Klasse",

--- a/Schreibtisch/vertriebsberichte-app/frontend/src/locales/de/reports.json
+++ b/Schreibtisch/vertriebsberichte-app/frontend/src/locales/de/reports.json
@@ -41,58 +41,58 @@
     "loadReportError": "Fehler beim Laden des Berichts"
   },
   "filters": {
-    "title": "🔍 Erweiterte Filter",
+    "title": "Erweiterte Filter",
     "activeLabel": "Filter aktiv",
     "reset": "Zurücksetzen",
     "resetAll": "Alle Filter zurücksetzen",
     "close": "Filter schließen",
     "activeMessage": "Filter sind aktiv - Ergebnisse werden automatisch gefiltert",
     "search": {
-      "label": "🔎 Schnellsuche",
+      "label": "Schnellsuche",
       "placeholder": "Suche in Berichten, Todos, Kundennamen, Ansprechpartnern..."
     },
     "dates": {
-      "fromDate": "📅 Von Datum",
-      "toDate": "📅 Bis Datum"
+      "fromDate": "Von Datum",
+      "toDate": "Bis Datum"
     },
     "customer": {
-      "number": "🏷️ Kundennummer",
+      "number": "️ Kundennummer",
       "numberPlaceholder": "z.B. K12345",
-      "name": "🏢 Kundenname", 
+      "name": "Kundenname", 
       "namePlaceholder": "z.B. Musterfirma GmbH"
     },
     "employee": {
-      "name": "👤 Mitarbeitername",
+      "name": "Mitarbeitername",
       "placeholder": "z.B. Max Mustermann"
     },
     "location": {
-      "label": "📍 Ort",
+      "label": "Ort",
       "placeholder": "z.B. München"
     },
     "classification": {
-      "label": "⭐ Klassifizierung",
+      "label": "Klassifizierung",
       "all": "Alle Klassen",
       "premium": "A - Premium",
       "standard": "B - Standard", 
       "basic": "C - Basis"
     },
     "status": {
-      "label": "📋 Status"
+      "label": "Status"
     },
     "newCustomer": {
-      "label": "🆕 Neukunde",
+      "label": "Neukunde",
       "all": "Alle Kunden",
       "onlyNew": "Nur Neukunden", 
       "onlyExisting": "Nur Bestandskunden"
     },
     "orderValue": {
-      "min": "💰 Min. Auftragswert (€)",
-      "max": "💰 Max. Auftragswert (€)",
+      "min": "Min. Auftragswert (€)",
+      "max": "Max. Auftragswert (€)",
       "minPlaceholder": "z.B. 1000",
       "maxPlaceholder": "z.B. 50000"
     },
     "sorting": {
-      "sortBy": "🔄 Sortieren nach",
+      "sortBy": "Sortieren nach",
       "sortOrder": "↕️ Sortierrichtung",
       "fields": {
         "date": "Datum",
@@ -119,17 +119,17 @@
     "nextVisit": "Nächster Besuch"
   },
   "list": {
-    "title": "📋 Besuchsberichte",
+    "title": "Besuchsberichte",
     "loading": "Lade Berichte...",
     "found": "Berichte gefunden",
-    "newReport": "➕ Neuer Bericht",
-    "employee": "🧑‍💼 Mitarbeiter:",
+    "newReport": "Neuer Bericht",
+    "employee": "Mitarbeiter:",
     "shortReportLabel": "Kurzbericht:",
-    "edit": "✏️ Bearbeiten",
-    "delete": "🗑️ Löschen",
-    "orderLabel": "💰 Auftrag:",
-    "offerLabel": "📊 Angebot:",
-    "newCustomerBadge": "🆕 Neukunde",
+    "edit": "️ Bearbeiten",
+    "delete": "️ Löschen",
+    "orderLabel": "Auftrag:",
+    "offerLabel": "Angebot:",
+    "newCustomerBadge": "Neukunde",
     "deleteConfirm": "Möchten Sie diesen Bericht wirklich löschen?",
     "deleteError": "Fehler beim Löschen des Berichts"
   },
@@ -146,7 +146,7 @@
     "noReportsYet": "Noch keine Berichte vorhanden",
     "adjustFilters": "Versuchen Sie, Ihre Filter anzupassen oder zurückzusetzen.",
     "createFirst": "Erstellen Sie Ihren ersten Besuchsbericht.",
-    "createFirstButton": "➕ Ersten Bericht erstellen"
+    "createFirstButton": "Ersten Bericht erstellen"
   },
   "edit": {
     "classification": {

--- a/Schreibtisch/vertriebsberichte-app/frontend/src/locales/en/admin.json
+++ b/Schreibtisch/vertriebsberichte-app/frontend/src/locales/en/admin.json
@@ -1,5 +1,5 @@
 {
-  "title": "👑 Admin Dashboard",
+  "title": "Admin Dashboard",
   "welcome": "Welcome, {{name}}! Manage users and roles.",
   "accessDenied": {
     "title": "Access Denied",
@@ -12,7 +12,7 @@
     "employees": "Employees"
   },
   "userManagement": {
-    "title": "👥 All Users",
+    "title": "All Users",
     "table": {
       "user": "User",
       "role": "Role",
@@ -26,7 +26,7 @@
     }
   },
   "roleAssignment": {
-    "title": "🔧 Assign Role",
+    "title": "Assign Role",
     "selectUser": "Select User",
     "selectRole": "New Role",
     "userPlaceholder": "-- Select User --",

--- a/Schreibtisch/vertriebsberichte-app/frontend/src/locales/en/common.json
+++ b/Schreibtisch/vertriebsberichte-app/frontend/src/locales/en/common.json
@@ -4,7 +4,7 @@
     "dashboard": "Dashboard",
     "reports": "Reports",
     "analytics": "Analytics",
-    "personalAnalytics": "🔍 Analytics",
+    "personalAnalytics": "Analytics",
     "globalStatistics": "Global Statistics",
     "adminDashboard": "User Management",
     "logout": "Logout"
@@ -47,7 +47,7 @@
     "existing": "Existing Customers Only"
   },
   "analytics": {
-    "title": "🔍 Analytics Dashboard",
+    "title": "Analytics Dashboard",
     "subtitle": "Personal performance analysis for",
     "loading": "Loading analytics data...",
     "noData": "No analytics data available",
@@ -66,13 +66,13 @@
       "newCustomers": "New Customers"
     },
     "charts": {
-      "monthlyTrends": "📈 Monthly Trends",
-      "statusDistribution": "📋 Status Distribution",
-      "recentActivity": "⚡ Recent Activity",
+      "monthlyTrends": "Monthly Trends",
+      "statusDistribution": "Status Distribution",
+      "recentActivity": "Recent Activity",
       "reports": "reports"
     },
     "insights": {
-      "title": "💡 Performance Insights",
+      "title": "Performance Insights",
       "avgPerReport": "Average per report",
       "completionRate": "Completion rate",
       "newCustomerRate": "New customer rate"

--- a/Schreibtisch/vertriebsberichte-app/frontend/src/locales/en/globalStats.json
+++ b/Schreibtisch/vertriebsberichte-app/frontend/src/locales/en/globalStats.json
@@ -1,12 +1,12 @@
 {
-  "title": "🌍 Global Statistics",
+  "title": "Global Statistics",
   "subtitle": "Overview of all reports, employees and customers",
   "accessDenied": {
     "title": "Access Denied",
     "message": "You don't have permission to access these global statistics."
   },
   "dateFilter": {
-    "title": "📅 Filter Time Period",
+    "title": "Filter Time Period",
     "fromDate": "From Date",
     "toDate": "To Date",
     "resetFilters": "Reset Filters",
@@ -24,7 +24,7 @@
     "cCustomers": "C-Customers"
   },
   "employeePerformance": {
-    "title": "🏆 Employee Performance",
+    "title": "Employee Performance",
     "headers": {
       "employee": "Employee",
       "region": "Region",
@@ -35,7 +35,7 @@
     }
   },
   "topCustomers": {
-    "title": "⭐ Top 20 Customers",
+    "title": "Top 20 Customers",
     "headers": {
       "customer": "Customer",
       "class": "Class",

--- a/Schreibtisch/vertriebsberichte-app/frontend/src/locales/en/reports.json
+++ b/Schreibtisch/vertriebsberichte-app/frontend/src/locales/en/reports.json
@@ -40,58 +40,58 @@
     "loadReportError": "Error loading report"
   },
   "filters": {
-    "title": "🔍 Advanced Filters",
+    "title": "Advanced Filters",
     "activeLabel": "Filters Active",
     "reset": "Reset",
     "resetAll": "Reset All Filters",
     "close": "Close Filters",
     "activeMessage": "Filters are active - results are automatically filtered",
     "search": {
-      "label": "🔎 Quick Search",
+      "label": "Quick Search",
       "placeholder": "Search in reports, todos, customer names, contacts..."
     },
     "dates": {
-      "fromDate": "📅 From Date",
-      "toDate": "📅 To Date"
+      "fromDate": "From Date",
+      "toDate": "To Date"
     },
     "customer": {
-      "number": "🏷️ Customer Number",
+      "number": "️ Customer Number",
       "numberPlaceholder": "e.g. K12345",
-      "name": "🏢 Customer Name", 
+      "name": "Customer Name", 
       "namePlaceholder": "e.g. Example Corp"
     },
     "employee": {
-      "name": "👤 Employee Name",
+      "name": "Employee Name",
       "placeholder": "e.g. John Doe"
     },
     "location": {
-      "label": "📍 Location",
+      "label": "Location",
       "placeholder": "e.g. Munich"
     },
     "classification": {
-      "label": "⭐ Classification",
+      "label": "Classification",
       "all": "All Classes",
       "premium": "A - Premium",
       "standard": "B - Standard", 
       "basic": "C - Basic"
     },
     "status": {
-      "label": "📋 Status"
+      "label": "Status"
     },
     "newCustomer": {
-      "label": "🆕 New Customer",
+      "label": "New Customer",
       "all": "All Customers",
       "onlyNew": "New Customers Only", 
       "onlyExisting": "Existing Customers Only"
     },
     "orderValue": {
-      "min": "💰 Min. Order Value (€)",
-      "max": "💰 Max. Order Value (€)",
+      "min": "Min. Order Value (€)",
+      "max": "Max. Order Value (€)",
       "minPlaceholder": "e.g. 1000",
       "maxPlaceholder": "e.g. 50000"
     },
     "sorting": {
-      "sortBy": "🔄 Sort by",
+      "sortBy": "Sort by",
       "sortOrder": "↕️ Sort Order",
       "fields": {
         "date": "Date",
@@ -118,17 +118,17 @@
     "nextVisit": "Next Visit"
   },
   "list": {
-    "title": "📋 Visit Reports",
+    "title": "Visit Reports",
     "loading": "Loading reports...",
     "found": "reports found",
-    "newReport": "➕ New Report",
-    "employee": "🧑‍💼 Employee:",
+    "newReport": "New Report",
+    "employee": "Employee:",
     "shortReportLabel": "Short report:",
-    "edit": "✏️ Edit",
-    "delete": "🗑️ Delete",
-    "orderLabel": "💰 Order:",
-    "offerLabel": "📊 Offer:",
-    "newCustomerBadge": "🆕 New Customer",
+    "edit": "️ Edit",
+    "delete": "️ Delete",
+    "orderLabel": "Order:",
+    "offerLabel": "Offer:",
+    "newCustomerBadge": "New Customer",
     "deleteConfirm": "Do you really want to delete this report?",
     "deleteError": "Error deleting report"
   },
@@ -145,7 +145,7 @@
     "noReportsYet": "No reports available yet",
     "adjustFilters": "Try adjusting your filters or resetting them.",
     "createFirst": "Create your first visit report.",
-    "createFirstButton": "➕ Create First Report"
+    "createFirstButton": "Create First Report"
   },
   "edit": {
     "classification": {

--- a/Schreibtisch/vertriebsberichte-app/frontend/src/pages/AdminDashboard.tsx
+++ b/Schreibtisch/vertriebsberichte-app/frontend/src/pages/AdminDashboard.tsx
@@ -73,15 +73,6 @@ const AdminDashboard: React.FC = () => {
     }
   };
 
-  const getRoleIcon = (roleName: string | null) => {
-    switch (roleName) {
-      case 'admin': return '👑';
-      case 'manager': return '📊';
-      case 'employee': return '👤';
-      default: return '❓';
-    }
-  };
-
   const getRoleBadgeColor = (roleName: string | null) => {
     switch (roleName) {
       case 'admin': return 'bg-red-100 text-red-800';
@@ -126,10 +117,7 @@ const AdminDashboard: React.FC = () => {
           <div className="bg-white overflow-hidden shadow rounded-lg">
             <div className="p-5">
               <div className="flex items-center">
-                <div className="flex-shrink-0">
-                  <span className="text-2xl">👥</span>
-                </div>
-                <div className="ml-5 w-0 flex-1">
+                <div className="flex-1">
                   <dl>
                     <dt className="text-sm font-medium text-gray-500 truncate">
                       {t('admin:statistics.totalUsers')}
@@ -146,10 +134,7 @@ const AdminDashboard: React.FC = () => {
           <div className="bg-white overflow-hidden shadow rounded-lg">
             <div className="p-5">
               <div className="flex items-center">
-                <div className="flex-shrink-0">
-                  <span className="text-2xl">👑</span>
-                </div>
-                <div className="ml-5 w-0 flex-1">
+                <div className="flex-1">
                   <dl>
                     <dt className="text-sm font-medium text-gray-500 truncate">
                       {t('admin:statistics.administrators')}
@@ -166,10 +151,7 @@ const AdminDashboard: React.FC = () => {
           <div className="bg-white overflow-hidden shadow rounded-lg">
             <div className="p-5">
               <div className="flex items-center">
-                <div className="flex-shrink-0">
-                  <span className="text-2xl">📊</span>
-                </div>
-                <div className="ml-5 w-0 flex-1">
+                <div className="flex-1">
                   <dl>
                     <dt className="text-sm font-medium text-gray-500 truncate">
                       {t('admin:statistics.managers')}
@@ -186,10 +168,7 @@ const AdminDashboard: React.FC = () => {
           <div className="bg-white overflow-hidden shadow rounded-lg">
             <div className="p-5">
               <div className="flex items-center">
-                <div className="flex-shrink-0">
-                  <span className="text-2xl">👤</span>
-                </div>
-                <div className="ml-5 w-0 flex-1">
+                <div className="flex-1">
                   <dl>
                     <dt className="text-sm font-medium text-gray-500 truncate">
                       {t('admin:statistics.employees')}
@@ -243,7 +222,7 @@ const AdminDashboard: React.FC = () => {
                 <option value="">{t('admin:roleAssignment.rolePlaceholder')}</option>
                 {roles.map(role => (
                   <option key={role.id} value={role.id}>
-                    {getRoleIcon(role.name)} {role.name} - {role.description}
+                    {role.name} - {role.description}
                   </option>
                 ))}
               </select>
@@ -265,7 +244,7 @@ const AdminDashboard: React.FC = () => {
               <p className="text-sm text-blue-800">
                 <strong>{t('admin:userManagement.roleInfo.current')}</strong> {selectedUser.name} {t('admin:userManagement.roleInfo.hasRole')}{' '}
                 <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getRoleBadgeColor(selectedUser.roleName)}`}>
-                  {getRoleIcon(selectedUser.roleName)} {selectedUser.roleName || t('admin:userManagement.roleInfo.noRole')}
+                  {selectedUser.roleName || t('admin:userManagement.roleInfo.noRole')}
                 </span>
               </p>
             </div>
@@ -308,7 +287,7 @@ const AdminDashboard: React.FC = () => {
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
                       <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getRoleBadgeColor(user.roleName)}`}>
-                        {getRoleIcon(user.roleName)} {user.roleName || t('admin:userManagement.roleInfo.noRole')}
+                        {user.roleName || t('admin:userManagement.roleInfo.noRole')}
                       </span>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">

--- a/Schreibtisch/vertriebsberichte-app/frontend/src/pages/Analytics.tsx
+++ b/Schreibtisch/vertriebsberichte-app/frontend/src/pages/Analytics.tsx
@@ -162,12 +162,7 @@ const Analytics = () => {
         <div className="bg-white overflow-hidden shadow rounded-lg">
           <div className="p-5">
             <div className="flex items-center">
-              <div className="flex-shrink-0">
-                <div className="w-8 h-8 bg-blue-500 rounded-md flex items-center justify-center">
-                  <span className="text-white font-bold">📄</span>
-                </div>
-              </div>
-              <div className="ml-5 w-0 flex-1">
+              <div className="flex-1">
                 <dl>
                   <dt className="text-sm font-medium text-gray-500 truncate">
                     {t('common:analytics.kpi.totalReports')}
@@ -184,12 +179,7 @@ const Analytics = () => {
         <div className="bg-white overflow-hidden shadow rounded-lg">
           <div className="p-5">
             <div className="flex items-center">
-              <div className="flex-shrink-0">
-                <div className="w-8 h-8 bg-green-500 rounded-md flex items-center justify-center">
-                  <span className="text-white font-bold">💰</span>
-                </div>
-              </div>
-              <div className="ml-5 w-0 flex-1">
+              <div className="flex-1">
                 <dl>
                   <dt className="text-sm font-medium text-gray-500 truncate">
                     {t('common:analytics.kpi.totalRevenue')}
@@ -206,12 +196,7 @@ const Analytics = () => {
         <div className="bg-white overflow-hidden shadow rounded-lg">
           <div className="p-5">
             <div className="flex items-center">
-              <div className="flex-shrink-0">
-                <div className="w-8 h-8 bg-yellow-500 rounded-md flex items-center justify-center">
-                  <span className="text-white font-bold">📊</span>
-                </div>
-              </div>
-              <div className="ml-5 w-0 flex-1">
+              <div className="flex-1">
                 <dl>
                   <dt className="text-sm font-medium text-gray-500 truncate">
                     {t('common:analytics.kpi.avgOrderValue')}
@@ -228,12 +213,7 @@ const Analytics = () => {
         <div className="bg-white overflow-hidden shadow rounded-lg">
           <div className="p-5">
             <div className="flex items-center">
-              <div className="flex-shrink-0">
-                <div className="w-8 h-8 bg-purple-500 rounded-md flex items-center justify-center">
-                  <span className="text-white font-bold">🆕</span>
-                </div>
-              </div>
-              <div className="ml-5 w-0 flex-1">
+              <div className="flex-1">
                 <dl>
                   <dt className="text-sm font-medium text-gray-500 truncate">
                     {t('common:analytics.kpi.newCustomers')}
@@ -314,26 +294,19 @@ const Analytics = () => {
             {analyticsData.recentActivity.map((activity, index) => (
               <li key={index} className="px-6 py-4 hover:bg-gray-50">
                 <div className="flex items-center justify-between">
-                  <div className="flex items-center">
-                    <div className="flex-shrink-0">
-                      <div className="w-10 h-10 bg-indigo-100 rounded-full flex items-center justify-center">
-                        <span className="text-indigo-600 font-medium text-sm">📄</span>
-                      </div>
+                  <div>
+                    <div className="text-sm font-medium text-gray-900">
+                      {activity.kunde_name}
                     </div>
-                    <div className="ml-4">
-                      <div className="text-sm font-medium text-gray-900">
-                        {activity.kunde_name}
-                      </div>
-                      <div className="text-sm text-gray-500">
-                        {new Date(activity.date).toLocaleDateString(i18n.language === 'en' ? 'en-US' : 'de-DE')}
-                      </div>
+                    <div className="text-sm text-gray-500">
+                      {new Date(activity.date).toLocaleDateString(i18n.language === 'en' ? 'en-US' : 'de-DE')}
                     </div>
                   </div>
                   <div className="flex items-center space-x-4">
                     <div className="text-sm font-medium text-gray-900">
                       {formatCurrency(activity.auftragswert)}
                     </div>
-                    <span className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${getStatusColor(activity.status)}`}>
+                    <span className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${getStatusColor(activity.status)}`}> 
                       {t(`status:process.${activity.status.toLowerCase()}`, { defaultValue: activity.status })}
                     </span>
                   </div>

--- a/Schreibtisch/vertriebsberichte-app/frontend/src/pages/GlobalStatistics.tsx
+++ b/Schreibtisch/vertriebsberichte-app/frontend/src/pages/GlobalStatistics.tsx
@@ -201,10 +201,7 @@ const GlobalStatistics: React.FC = () => {
               <div className="bg-white overflow-hidden shadow rounded-lg">
                 <div className="p-5">
                   <div className="flex items-center">
-                    <div className="flex-shrink-0">
-                      <span className="text-2xl">📊</span>
-                    </div>
-                    <div className="ml-5 w-0 flex-1">
+                    <div className="flex-1">
                       <dl>
                         <dt className="text-sm font-medium text-gray-500 truncate">
                           {t('globalStats:kpis.totalReports')}
@@ -221,10 +218,7 @@ const GlobalStatistics: React.FC = () => {
               <div className="bg-white overflow-hidden shadow rounded-lg">
                 <div className="p-5">
                   <div className="flex items-center">
-                    <div className="flex-shrink-0">
-                      <span className="text-2xl">👥</span>
-                    </div>
-                    <div className="ml-5 w-0 flex-1">
+                    <div className="flex-1">
                       <dl>
                         <dt className="text-sm font-medium text-gray-500 truncate">
                           {t('globalStats:kpis.totalCustomers')}
@@ -241,10 +235,7 @@ const GlobalStatistics: React.FC = () => {
               <div className="bg-white overflow-hidden shadow rounded-lg">
                 <div className="p-5">
                   <div className="flex items-center">
-                    <div className="flex-shrink-0">
-                      <span className="text-2xl">💰</span>
-                    </div>
-                    <div className="ml-5 w-0 flex-1">
+                    <div className="flex-1">
                       <dl>
                         <dt className="text-sm font-medium text-gray-500 truncate">
                           {t('globalStats:kpis.totalOrderValue')}
@@ -261,10 +252,7 @@ const GlobalStatistics: React.FC = () => {
               <div className="bg-white overflow-hidden shadow rounded-lg">
                 <div className="p-5">
                   <div className="flex items-center">
-                    <div className="flex-shrink-0">
-                      <span className="text-2xl">📈</span>
-                    </div>
-                    <div className="ml-5 w-0 flex-1">
+                    <div className="flex-1">
                       <dl>
                         <dt className="text-sm font-medium text-gray-500 truncate">
                           {t('globalStats:kpis.newCustomers')}

--- a/Schreibtisch/vertriebsberichte-app/frontend/src/pages/Reports.tsx
+++ b/Schreibtisch/vertriebsberichte-app/frontend/src/pages/Reports.tsx
@@ -165,10 +165,10 @@ const Reports = () => {
                         <div className="flex items-center justify-between">
                           <div>
                             <p className="text-sm font-medium text-indigo-600 truncate">
-                              🏢 {report.kunde_name} ({report.kunde_nr})
+                               {report.kunde_name} ({report.kunde_nr})
                             </p>
                             <p className="text-sm text-gray-500">
-                              👤 {report.ansprechpartner} • 📍 {report.ort}
+                               {report.ansprechpartner} •  {report.ort}
                             </p>
                             {report.mitarbeiter_name && (
                               <p className="text-sm text-gray-500">
@@ -200,10 +200,10 @@ const Reports = () => {
                         <div className="mt-2 sm:flex sm:justify-between">
                           <div className="sm:flex sm:space-x-4">
                             <p className="flex items-center text-sm text-gray-500">
-                              📅 {format(new Date(report.datum), 'dd.MM.yyyy', { locale: de })}
+                               {format(new Date(report.datum), 'dd.MM.yyyy', { locale: de })}
                             </p>
                             <p className="mt-2 flex items-center text-sm text-gray-500 sm:mt-0">
-                              🌍 {report.region_name}
+                               {report.region_name}
                             </p>
                           </div>
                           <div className="mt-2 flex items-center text-sm text-gray-500 sm:mt-0 space-x-4">
@@ -323,7 +323,6 @@ const Reports = () => {
         </>
       ) : (
         <div className="text-center py-12 bg-white rounded-lg shadow">
-          <div className="text-6xl mb-4">📋</div>
           <h3 className="text-lg font-medium text-gray-900 mb-2">
             {Object.values(filters).some(v => v !== '' && v !== 'datum' && v !== 'desc')
               ? t('reports:empty.noReportsFound')


### PR DESCRIPTION
## Summary
- Replace flag icons in language switcher with plain language codes
- Remove emoji decorations across layout, dashboards, and reports
- Clean translation strings to avoid emoji and keep professional tone

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_689aed0745e8832291217f3cea5830fc